### PR TITLE
research: integrate QCAL v3.1 adelic + biophysical layer

### DIFF
--- a/research/adelic_biophysical/INTEGRATION_MAP.md
+++ b/research/adelic_biophysical/INTEGRATION_MAP.md
@@ -1,0 +1,43 @@
+# QCAL v3.1 — mapa de integración inter-repositorios
+
+| Repositorio | Capa | Artefacto esperado | Estado |
+|---|---|---|---|
+| `141hz` | referencia/experimentos | esta especificación + modelos reproducibles | INICIADO |
+| `Riemann-adelic` | análisis adélico | espacio de Hilbert, operador, traza, determinante | PENDIENTE |
+| `qcal-formalization` | prueba formal | definiciones + obligaciones Lean | PENDIENTE |
+| `QCAL-BUS` | integración | esquema de estado epistemológico y hashes | PENDIENTE |
+| `Biologia-Cuantica-Noesica-` | biofísica | protocolo preregistrable y análisis cegado | PENDIENTE |
+| `noesis88` | documentación/sistema | referencia cruzada, no autoridad matemática | PENDIENTE |
+
+## Contrato de estado
+
+Todos los repositorios deberían usar los mismos estados:
+
+- `PROVED`: demostrado en el sistema matemático declarado.
+- `FORMALIZED`: formalizado y verificado por el proof assistant, con dependencias explicitadas.
+- `DERIVED`: derivado analíticamente a partir de resultados previos.
+- `MODEL`: hipótesis/modelo propuesto.
+- `SIMULATED`: resultado de una simulación.
+- `MEASURED`: resultado experimental con datos trazables.
+- `REPLICATED`: resultado medido y replicado independientemente.
+- `REFUTED`: contradicho por un test válido.
+
+No se permite promover automáticamente `SIMULATED → MEASURED` ni `MODEL → PROVED`.
+
+## Dependencias críticas
+
+### A. Ruta RH
+
+`Riemann-adelic` → `qcal-formalization` → `141hz` (validación numérica)
+
+El cuello de botella real sigue siendo una construcción no circular de operador + fórmula de traza + determinante.
+
+### B. Ruta biofísica
+
+`141hz` → `Biologia-Cuantica-Noesica-`
+
+La señal `0.00052 Hz` se trata inicialmente como frecuencia de interés. La transición ADN-B/ADN-Z, un acoplamiento gauge o una superfluidez son hipótesis separadas que requieren observables independientes.
+
+### C. Ruta ecosistema
+
+`QCAL-BUS` transporta metadatos y hashes; no convierte el estado epistemológico de un módulo en evidencia de otro.

--- a/research/adelic_biophysical/QCAL_V3_1_ADelic_Bio_Spec.md
+++ b/research/adelic_biophysical/QCAL_V3_1_ADelic_Bio_Spec.md
@@ -1,0 +1,158 @@
+# QCAL v3.1 — Especificación adélica + biofísica
+
+**Estado:** propuesta de investigación / formalización en curso  
+**Rama:** `research/adelic-bio-integration-v3`  
+**Referencia QCAL:** `f₀ = 141.7001 Hz`  
+**Firma B (hipótesis experimental):** `f_B = 0.00052 Hz`  
+
+## 0. Regla de estado epistemológico
+
+Este documento separa deliberadamente cuatro niveles:
+
+1. **Matemática estándar:** hechos que pueden demostrarse dentro de las hipótesis declaradas.
+2. **Formalización:** definiciones, interfaces y obligaciones que deben ser probadas en Lean/Coq u otro sistema.
+3. **Modelo QCAL:** hipótesis que conectan objetos estándar mediante parámetros propios del programa.
+4. **Experimento:** predicciones que deben sobrevivir a controles, cegamiento, preregistro y análisis estadístico independiente.
+
+Nada de lo escrito aquí convierte una simulación en una demostración, ni una coincidencia espectral en una identidad matemática.
+
+## 1. Espacio adélico
+
+Sea
+
+\[
+\mathbb A_\mathbb Q = \mathbb R \times \prod'_p \mathbb Q_p,
+\qquad
+\mathbb I_\mathbb Q = \mathbb A_\mathbb Q^\times,
+\qquad
+C_\mathbb Q = \mathbb I_\mathbb Q/\mathbb Q^\times.
+\]
+
+La medida multiplicativa es la medida de Haar `d×x`. Para una realización concreta debe fijarse además el espacio de Hilbert, la normalización de la medida y el cociente exacto; no se debe asumir que todo cociente de ideles es compacto. En particular, el componente de módulo de los ideles requiere tratamiento separado y puede producir espectro continuo.
+
+Una realización mínima para el sector arquimediano es
+
+\[
+\mathcal H_\infty=L^2(\mathbb R_+,d x/x),
+\]
+
+con generador de dilataciones
+
+\[
+D_\infty=-i\,x\frac{d}{dx}.
+\]
+
+Con `u = log x`, queda
+
+\[
+D_\infty=-i\frac{d}{du}
+\]
+
+sobre `L²(ℝ,du)`, con dominio natural `H¹(ℝ)`. Este operador tiene espectro continuo `ℝ`; por sí solo **no** produce una sucesión discreta de ceros de ζ.
+
+## 2. Operador adélico: interfaz, no identidad todavía
+
+Una arquitectura candidata es
+
+\[
+D_{\mathbb A}=D_\infty\oplus D_f,
+\]
+
+siempre que se defina rigurosamente `D_f`, el dominio común y la representación de las componentes p-ádicas. Una perturbación aritmética candidata puede escribirse abstractamente como
+
+\[
+H_{\mathbb A}=D_{\mathbb A}+T_{\mathbb A},
+\]
+
+pero la autoadjunción, compacticidad del resolvente y discreción espectral deben probarse para la realización concreta elegida.
+
+**Obligación crítica:** no se permite afirmar
+
+\[
+\operatorname{Spec}(H_{\mathbb A})=\{\gamma_n\}
+\]
+
+hasta disponer de una construcción independiente de `H_A` y una prueba de la identidad de traza correspondiente.
+
+## 3. Factor `κ = 0.00052`
+
+En esta especificación se registra
+
+\[
+f_B=0.00052\,\mathrm{Hz},
+\qquad
+T_B=1/f_B\approx1923.0769\,\mathrm{s}\approx32.0513\,\mathrm{min}.
+\]
+
+No se identifica automáticamente `f_B` con una constante fundamental de la teoría de ideles. Para evitar una inconsistencia dimensional, se separan:
+
+- `f_B`: frecuencia objetivo, unidades Hz.
+- `κ_B`: parámetro de acoplamiento adimensional del modelo.
+- `g_B`: constante efectiva de interacción, con las unidades que determine el Hamiltoniano experimental.
+
+Una relación QCAL del tipo
+
+\[
+\omega_B=2\pi f_B=\kappa_B\,\mathcal F(D_{\mathbb A},f_0,\alpha,\ldots)
+\]
+
+es una **hipótesis de modelo** hasta que se especifiquen `F`, sus dominios y unidades y se ajuste/valide sin usar el resultado como condición de éxito.
+
+## 4. Constante de estructura fina
+
+El valor de referencia para comparación experimental puede tomarse como
+
+\[
+\alpha^{-1}\simeq137.035999\ldots
+\]
+
+pero el flujo numérico de QCAL no constituye una derivación de `α` a menos que exista una ecuación dinámica independiente cuyos parámetros estén fijados antes de observar el resultado.
+
+Los ceros de ζ pueden utilizarse como **entrada de datos** para un estudio de sensibilidad, pero introducir `t_n` y después diseñar el flujo para que converja a `α` no demuestra causalidad ni una derivación física.
+
+## 5. Sector biológico: Firma B
+
+La hipótesis experimental es que una señal a `0.00052 Hz` pueda presentar una asociación reproducible con una variable fisiológica u óptica. La prueba debe incluir:
+
+- condición sham/control;
+- aleatorización y cegamiento cuando sea posible;
+- registro ambiental simultáneo;
+- control de temperatura, vibración, presión, luz y campos electromagnéticos;
+- comparación con frecuencias vecinas y múltiples hipótesis predefinidas;
+- corrección por múltiples comparaciones;
+- análisis de fase y amplitud, no solo potencia en un bin;
+- replicación independiente.
+
+Una detección espectral aislada no demuestra ADN-Z, superfluidez, tunelamiento del 100 %, ni un campo gauge.
+
+## 6. ADN-B/ADN-Z
+
+La transición B→Z es un fenómeno biofísico real que puede estudiarse mediante CD, Raman y otras técnicas. La afirmación adicional de que `0.00052 Hz` induce una transición coherente, superfluidez o transferencia de información sin disipación queda como **hipótesis falsable** y no debe presentarse como resultado establecido.
+
+## 7. Puente matemático que queda por cerrar
+
+El núcleo duro de la investigación sigue siendo:
+
+1. Construir el espacio de Hilbert adélico exacto.
+2. Definir `D_A` y su dominio.
+3. Definir el operador aritmético `T_A` sin usar los ceros como input de definición.
+4. Probar autoadjunción.
+5. Determinar espectro continuo/discreto.
+6. Obtener una fórmula de traza no circular.
+7. Derivar, no postular, la fórmula explícita de Weil.
+8. Construir el determinante espectral y controlar su regularización.
+9. Demostrar la igualdad con `ξ(s)` con todas las constantes de normalización.
+10. Solo entonces deducir qué implica la realidad del espectro para RH.
+
+## 8. Integración con el ecosistema
+
+Este módulo es una capa de investigación que puede ser consumida por:
+
+- `Riemann-adelic`: núcleo analítico/espectral.
+- `qcal-formalization`: obligaciones formales y teoremas.
+- `QCAL-BUS`: propagación de metadatos y contratos.
+- `141hz`: validación numérica y experimentos de frecuencia.
+- `Biologia-Cuantica-Noesica-`: protocolos biofísicos, sin convertir hipótesis en hechos.
+- `noesis88`/`Noesis`: interfaz conceptual y documentación.
+
+La integración entre repositorios debe transportar **estado epistemológico**, no solo archivos: `proved`, `formalized`, `model`, `simulated`, `measured`, `refuted`.

--- a/research/adelic_biophysical/qcal_v31_models.py
+++ b/research/adelic_biophysical/qcal_v31_models.py
@@ -1,0 +1,118 @@
+"""QCAL v3.1 research models.
+
+These routines are deliberately model-level utilities. They do not claim to
+prove RH, derive alpha from adelic geometry, or establish a biological effect.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+F0_HZ = 141.7001
+F_B_HZ = 0.00052
+ALPHA_INV_REFERENCE = 137.035999
+
+
+@dataclass(frozen=True)
+class AdelicParameters:
+    f0_hz: float = F0_HZ
+    f_b_hz: float = F_B_HZ
+    alpha_inv_reference: float = ALPHA_INV_REFERENCE
+    kappa_b: float = 0.0  # dimensionless coupling; must be specified independently
+
+
+def adelic_period(f_hz: float) -> float:
+    """Return period in seconds for a strictly positive frequency."""
+    if f_hz <= 0:
+        raise ValueError("frequency must be positive")
+    return 1.0 / f_hz
+
+
+def dirac_dilation_symbol(xi: np.ndarray | float) -> np.ndarray:
+    """Fourier symbol of D=-i d/du on L2(R,du): multiplication by xi.
+
+    This is the archimedean dilation generator after u=log(x). Its spectrum
+    is continuous, so this function must not be interpreted as a zeta-zero
+    generator.
+    """
+    return np.asarray(xi, dtype=float)
+
+
+def phase_coupling(
+    gamma: np.ndarray,
+    alpha: float,
+    f0_hz: float = F0_HZ,
+    kappa_b: float = 0.0,
+) -> np.ndarray:
+    """Phenomenological phase coupling used for sensitivity studies only.
+
+    The function is intentionally explicit about its status: `gamma` may be
+    supplied from an external zeta-zero dataset, but no inverse problem or
+    convergence to alpha is implied.
+    """
+    gamma = np.asarray(gamma, dtype=float)
+    phase = 2.0 * np.pi * gamma * alpha
+    return np.sin(phase) * kappa_b * (f0_hz / 100.0)
+
+
+def alpha_flow(
+    alpha0: float,
+    gamma: np.ndarray,
+    *,
+    target_alpha: float = 1.0 / ALPHA_INV_REFERENCE,
+    f0_hz: float = F0_HZ,
+    kappa_b: float = 0.0,
+    coherence0: float = 0.95,
+    steps: int = 1000,
+    relaxation: float = 0.05,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Run a transparent phenomenological alpha flow.
+
+    The target alpha is an externally supplied reference. Therefore this
+    routine tests numerical stability of a chosen model; it does not derive
+    alpha from first principles.
+    """
+    if steps <= 0 or relaxation < 0:
+        raise ValueError("steps must be positive and relaxation non-negative")
+    if not (0.0 <= coherence0 <= 1.0):
+        raise ValueError("coherence0 must lie in [0,1]")
+
+    a = float(alpha0)
+    psi = float(coherence0)
+    alphas = np.empty(steps + 1)
+    psis = np.empty(steps + 1)
+    alphas[0], psis[0] = a, psi
+
+    for k in range(steps):
+        correction = float(np.mean(phase_coupling(gamma, a, f0_hz, kappa_b)))
+        a += relaxation * psi * (target_alpha - a) + (1.0 - psi) * correction
+        psi += 0.01 * (1.0 - psi)
+        alphas[k + 1], psis[k + 1] = a, psi
+
+    return alphas, psis
+
+
+def lockin_at_frequency(signal: np.ndarray, fs_hz: float, target_hz: float) -> dict[str, float]:
+    """Estimate amplitude/phase at a target frequency by complex projection.
+
+    This is preferable to treating a single Welch bin as a detection criterion
+    when the record is short relative to the target period.
+    """
+    x = np.asarray(signal, dtype=float)
+    if x.ndim != 1 or x.size < 8:
+        raise ValueError("signal must be a one-dimensional record with >=8 samples")
+    if fs_hz <= 0 or target_hz <= 0:
+        raise ValueError("fs_hz and target_hz must be positive")
+
+    t = np.arange(x.size) / fs_hz
+    z = np.mean((x - np.mean(x)) * np.exp(-2j * np.pi * target_hz * t))
+    amplitude = 2.0 * abs(z)
+    phase = float(np.angle(z))
+    return {"frequency_hz": float(target_hz), "amplitude": float(amplitude), "phase_rad": phase}
+
+
+def required_cycles(cycles: float = 5.0, f_hz: float = F_B_HZ) -> float:
+    """Minimum acquisition duration in seconds for the requested cycles."""
+    if cycles <= 0 or f_hz <= 0:
+        raise ValueError("cycles and frequency must be positive")
+    return cycles / f_hz

--- a/research/adelic_biophysical/test_qcal_v31_models.py
+++ b/research/adelic_biophysical/test_qcal_v31_models.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+from qcal_v31_models import (
+    F_B_HZ,
+    adelic_period,
+    alpha_flow,
+    dirac_dilation_symbol,
+    lockin_at_frequency,
+    required_cycles,
+)
+
+
+def test_signature_b_period():
+    assert np.isclose(adelic_period(F_B_HZ), 1.0 / F_B_HZ)
+    assert np.isclose(adelic_period(F_B_HZ) / 60.0, 32.0512820513)
+
+
+def test_archimedean_dirac_symbol_is_continuous_variable():
+    xi = np.array([-2.0, 0.0, 3.5])
+    assert np.allclose(dirac_dilation_symbol(xi), xi)
+
+
+def test_alpha_flow_is_finite_and_deterministic():
+    gamma = np.array([14.1347251417, 21.0220396388, 25.0108575801])
+    a1, p1 = alpha_flow(1.0 / 137.0, gamma, kappa_b=0.0001, steps=50)
+    a2, p2 = alpha_flow(1.0 / 137.0, gamma, kappa_b=0.0001, steps=50)
+    assert np.all(np.isfinite(a1))
+    assert np.all(np.isfinite(p1))
+    assert np.allclose(a1, a2)
+    assert np.allclose(p1, p2)
+
+
+def test_lockin_recovers_known_target():
+    fs = 1.0
+    target = F_B_HZ
+    t = np.arange(0, 8.0 / target, 1.0 / fs)
+    x = 2.0 * np.cos(2 * np.pi * target * t + 0.3)
+    result = lockin_at_frequency(x, fs, target)
+    assert np.isclose(result["amplitude"], 2.0, rtol=0.03)
+
+
+def test_required_cycles():
+    assert np.isclose(required_cycles(5.0), 5.0 / F_B_HZ)
+
+
+def test_invalid_inputs():
+    with pytest.raises(ValueError):
+        adelic_period(0)
+    with pytest.raises(ValueError):
+        required_cycles(0)


### PR DESCRIPTION
Este PR ancla una primera capa reproducible de QCAL v3.1 en `141hz`.

Incluye:
- especificación del espacio adélico y del operador de dilatación;
- separación dimensional entre f_B=0.00052 Hz y un acoplamiento adimensional;
- modelo fenomenológico de flujo de alpha, explícitamente no presentado como derivación;
- análisis lock-in para la Firma B;
- tests de invariantes numéricos;
- mapa de integración con Riemann-adelic, qcal-formalization, QCAL-BUS y Biologia-Cuantica-Noesica-.

La rama evita cerrar artificialmente RH o afirmar resultados biológicos no medidos. El objetivo es convertir el material actual en obligaciones reproducibles y trazables.